### PR TITLE
Fix bug with missing datafiles

### DIFF
--- a/src/main/java/juke/storage/Storage.java
+++ b/src/main/java/juke/storage/Storage.java
@@ -52,7 +52,9 @@ public class Storage extends JukeObject {
                 throw new JukeInitialisationException("Oh no! I am unable to create a directory to store your "
                                                               + "tasks! Please try again later!");
             }
-        } else if (!Files.exists(Storage.FILE_PATH)) {
+        }
+
+        if (!Files.exists(Storage.FILE_PATH)) {
             // if the dir exist but file doesn't, then just create the file
             try {
                 Files.createFile(Storage.FILE_PATH);


### PR DESCRIPTION
The bug has now been resolved, by making a minor adjustment to how the `Storage` initialising function checks and handles missing `data` folders and datafiles.